### PR TITLE
feat: hide section when 0 points

### DIFF
--- a/app/src/components/AwardDetail.tsx
+++ b/app/src/components/AwardDetail.tsx
@@ -165,7 +165,7 @@ export function AwardDetail({ award }: Props) {
         )}
       </CardContent>
 
-      {award.points == 0 && (
+      {award.points === 0 && (
         <p className="mt-4">
           This award cannot be claimed! There are few challenges to win this, check the challenge
           list and find out how you can win it!

--- a/app/src/components/AwardDetail.tsx
+++ b/app/src/components/AwardDetail.tsx
@@ -150,7 +150,7 @@ export function AwardDetail({ award }: Props) {
         </div>
         <div>
           <h1 className="text-2xl font-bold mb-2">{award.name}</h1>
-          <span className="text-blue-600 font-bold">{award.points} pts</span>
+          {award.points > 0 && <span className="text-blue-600 font-bold">{award.points} pts</span>}
         </div>
       </CardHeader>
 
@@ -165,40 +165,50 @@ export function AwardDetail({ award }: Props) {
         )}
       </CardContent>
 
-      <CardFooter>
-        {award.isSoldOut ? (
-          <CardSection>
-            <p className="text-sm text-neutral-600">
-              This award is currently sold out and cannot be claimed.
-            </p>
-          </CardSection>
-        ) : award.isSupervised ? (
-          <CardSection>
-            <h3 className="font-semibold mb-2">Verification Required</h3>
-            <p className="text-sm text-neutral-600">
-              This award needs to be verified by a supervisor. Click the button below to generate a
-              QR code for verification.
-            </p>
-          </CardSection>
-        ) : (
-          <CardSection>
-            <p className="text-sm text-neutral-600">Click the button below to claim this award.</p>
-          </CardSection>
-        )}
+      {award.points == 0 && (
+        <p className="mt-4">
+          This award cannot be claimed! There are few challenges to win this, check the challenge
+          list and find out how you can win it!
+        </p>
+      )}
+      {award.points > 0 && (
+        <CardFooter>
+          {award.isSoldOut ? (
+            <CardSection>
+              <p className="text-sm text-neutral-600">
+                This award is currently sold out and cannot be claimed.
+              </p>
+            </CardSection>
+          ) : award.isSupervised ? (
+            <CardSection>
+              <h3 className="font-semibold mb-2">Verification Required</h3>
+              <p className="text-sm text-neutral-600">
+                This award needs to be verified by a supervisor. Click the button below to generate
+                a QR code for verification.
+              </p>
+            </CardSection>
+          ) : (
+            <CardSection>
+              <p className="text-sm text-neutral-600">
+                Click the button below to claim this award.
+              </p>
+            </CardSection>
+          )}
 
-        <Button
-          onClick={handleRedeem}
-          disabled={isRedeeming || award.isSoldOut}
-          variant="accent"
-          className="w-full"
-        >
-          {isRedeeming
-            ? "Redeeming..."
-            : award.isSupervised
-              ? "Generate Verification QR"
-              : "Claim Award"}
-        </Button>
-      </CardFooter>
+          <Button
+            onClick={handleRedeem}
+            disabled={isRedeeming || award.isSoldOut}
+            variant="accent"
+            className="w-full"
+          >
+            {isRedeeming
+              ? "Redeeming..."
+              : award.isSupervised
+                ? "Generate Verification QR"
+                : "Claim Award"}
+          </Button>
+        </CardFooter>
+      )}
 
       {showQR && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">

--- a/app/src/components/ui/listItem.tsx
+++ b/app/src/components/ui/listItem.tsx
@@ -183,8 +183,8 @@ const ListItem = React.forwardRef<HTMLElement, ListItemProps>((props, ref) => {
             </h3>
             <p className="text-neutral-600 text-sm">{description}</p>
             <div className="flex items-center gap-4">
-              <span className="font-bold text-blue-600">{points} pts</span>
-              {isSupervised && !isCompleted && (
+              {points > 0 && <span className="font-bold text-blue-600">{points} pts</span>}
+              {isSupervised && !isCompleted && points > 0 && (
                 <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
                   Requires Verification
                 </span>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the code of conduct before creating a pull request
 👉 https://schroedinger-hat.org/page/code-of-conduct
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This feature hide the point description for special awards or things that cannot be got by points!
It show a special description too! 

<img width="416" height="194" alt="image" src="https://github.com/user-attachments/assets/20a66086-8624-4d83-b7d3-53898ce7c409" />
<img width="403" height="210" alt="image" src="https://github.com/user-attachments/assets/6315a509-e752-4300-acd7-5bbc6cd0ef0c" />
<img width="417" height="296" alt="image" src="https://github.com/user-attachments/assets/16cdf82b-aff3-4c41-bbd9-f4b37a08ed38" />


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.